### PR TITLE
Handle quoted tokens

### DIFF
--- a/lexer.c
+++ b/lexer.c
@@ -32,28 +32,49 @@ static t_type	get_type(char *s)
 	return (WORD);
 }
 
-static char	*extract_token(char *s, int *i)
+
+static char     *extract_token(char *s, int *i)
 {
-	int		start;
+        int             start;
+        char    quote;
+        char    *raw;
 
-	while (is_space(s[*i]))
-		(*i)++;
-	start = *i;
-	if (!s[start])
-		return (NULL);
-	if (s[*i] == '<' || s[*i] == '>' || s[*i] == '|')
-	{
-		(*i)++;
-		if (s[*i] == s[start])
-			(*i)++;
-	}
-	else
-		while (s[*i] && !is_space(s[*i])
-			&& s[*i] != '<' && s[*i] != '>' && s[*i] != '|')
-			(*i)++;
-	return (ft_substr(s, start, *i - start));
+        while (is_space(s[*i]))
+                (*i)++;
+        start = *i;
+        if (!s[start])
+                return (NULL);
+        if (s[*i] == '<' || s[*i] == '>' || s[*i] == '|')
+        {
+                (*i)++;
+                if (s[*i] == s[start])
+                        (*i)++;
+        }
+        else
+        {
+                while (s[*i] && !is_space(s[*i])
+                        && s[*i] != '<' && s[*i] != '>' && s[*i] != '|')
+                {
+                        if (s[*i] == '\'' || s[*i] == '"')
+                        {
+                                quote = s[*i];
+                                (*i)++;
+                                while (s[*i] && s[*i] != quote)
+                                        (*i)++;
+                                if (s[*i] == quote)
+                                        (*i)++;
+                        }
+                        else
+                                (*i)++;
+                }
+        }
+        raw = ft_substr(s, start, *i - start);
+        if (!raw)
+                return (NULL);
+        s = remove_quotes(raw);
+        free(raw);
+        return (s);
 }
-
 t_token	*lexer(char *s)
 {
 	t_token	*head;

--- a/minishell.h
+++ b/minishell.h
@@ -143,6 +143,7 @@ void	ft_free_split(char **arr);
 void	exit_msg(char *msg, int code);
 void	free_tokens(t_token *tok);
 void	free_cmds(t_cmd *cmd);
+char    *remove_quotes(char *s);
 
 /* ************************************************************************** */
 /*                                   SIGNALS                                  */

--- a/utils.c
+++ b/utils.c
@@ -54,7 +54,36 @@ void	free_cmds(t_cmd *cmd)
 			free(r);
 			r = r_next;
 		}
-		free(cmd);
-		cmd = tmp;
-	}
+                free(cmd);
+                cmd = tmp;
+        }
+}
+
+char    *remove_quotes(char *s)
+{
+        char    *res;
+        int             i;
+        int             j;
+
+        i = 0;
+        j = 0;
+        while (s && s[i])
+        {
+                if (s[i] != '\'' && s[i] != '"')
+                        j++;
+                i++;
+        }
+        res = malloc(j + 1);
+        if (!res)
+                return (NULL);
+        i = 0;
+        j = 0;
+        while (s && s[i])
+        {
+                if (s[i] != '\'' && s[i] != '"')
+                        res[j++] = s[i];
+                i++;
+        }
+        res[j] = '\0';
+        return (res);
 }


### PR DESCRIPTION
## Summary
- strip quotation marks from tokens
- recognize quoted sections when lexing

## Testing
- `make -s`
- `printf 'echo "hello world"\nexit\n' | ./minishell`
- `printf 'echo "abcdef" | grep def > test4.txt\nexit\n' | ./minishell`


------
https://chatgpt.com/codex/tasks/task_e_685a992e7634832aa73258da4a646625