### PR TITLE
Copy env to g_env

### DIFF
--- a/exit.c
+++ b/exit.c
@@ -12,6 +12,8 @@
 
 #include "minishell.h"
 
+extern char **g_env;
+
 static int	is_numeric(char *str)
 {
 	int	i;
@@ -40,7 +42,8 @@ int	ft_exit(char **args)
 		ft_putstr_fd("minishell: exit: ", 2);
 		ft_putstr_fd(args[1], 2);
 		ft_putendl_fd(": numeric argument required", 2);
-		exit(255);
+		ft_free_split(g_env);
+                exit(255);
 	}
 	if (args[1] && args[2])
 	{
@@ -48,5 +51,6 @@ int	ft_exit(char **args)
 		return (1);
 	}
 	code = args[1] ? ft_atoi(args[1]) : 0;
-	exit(code);
+	ft_free_split(g_env);
+        exit(code);
 }

--- a/prompt.c
+++ b/prompt.c
@@ -13,12 +13,15 @@
 #include "minishell.h"
 
 static char	*prompt(void);
-static int	handle_input(char *rl, char **env);
+static int	handle_input(char *rl);
 
 void	start_shell_loop(char **env)
 {
 	char	*rl;
 	char	*prompt_str;
+	g_env = dup_env(env);
+	if (!g_env)
+		exit_msg("Failed to copy environment", 1);
 
 	while (1)
 	{
@@ -29,16 +32,17 @@ void	start_shell_loop(char **env)
 		free(prompt_str);
 		if (!rl)
 			break ;
-		if (handle_input(rl, env))
+		if (handle_input(rl))
 		{
 			free(rl);
 			break ;
 		}
 		free(rl);
 	}
+	ft_free_split(g_env);
 }
 
-static int	handle_input(char *rl, char **env)
+static int	handle_input(char *rl)
 {
 	t_token	*tokens;
 	t_cmd	*cmds;
@@ -52,7 +56,7 @@ static int	handle_input(char *rl, char **env)
 	cmds = parse(tokens);
 	if (!cmds)
 		return (0);
-	execute(cmds, env);
+	execute(cmds, g_env);
 	free_tokens(tokens);
 	free_cmds(cmds);
 	return (0);

--- a/utils.c
+++ b/utils.c
@@ -11,11 +11,14 @@
 /* ************************************************************************** */
 
 #include "minishell.h"
+extern char **g_env;
 
 void	exit_msg(char *msg, int code)
 {
 	ft_putstr_fd("minishell: ", 2);
 	ft_putendl_fd(msg, 2);
+        if (g_env)
+                ft_free_split(g_env);
 	exit(code);
 }
 


### PR DESCRIPTION
## Summary
- copy initial environment to `g_env` when the shell loop starts
- free `g_env` before exiting
- use `g_env` when executing commands

## Testing
- `make --always-make`