### PR TITLE
Implement echo builtin quoting fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ LDFLAGS = -lreadline
 SRCS =	minishell.c\
 		utils.c\
 		prompt.c\
+		echo.c\
 
 # Object Files (automatiquement générés à partir de SRCS)
 OBJS = $(SRCS:.c=.o)

--- a/echo.c
+++ b/echo.c
@@ -1,0 +1,34 @@
+#include "minishell.h"
+
+static char *strip_quotes(char *str)
+{
+    size_t len;
+
+    if (!str)
+        return (NULL);
+    len = ft_strlen(str);
+    if (len >= 2 && ((str[0] == '\'' && str[len - 1] == '\'') ||
+        (str[0] == '"' && str[len - 1] == '"')))
+        return (ft_substr(str, 1, len - 2));
+    return (ft_strdup(str));
+}
+
+void    builtin_echo(char *arg)
+{
+    char *output;
+
+    if (!arg)
+    {
+        printf("\n");
+        return ;
+    }
+    output = strip_quotes(arg);
+    if (output)
+    {
+        printf("%s\n", output);
+        free(output);
+    }
+    else
+        printf("%s\n", arg);
+}
+

--- a/minishell.c
+++ b/minishell.c
@@ -12,12 +12,22 @@
 
 #include "minishell.h"
 
-int	handle_input(char *rl)
+int     handle_input(char *rl)
 {
-	if (ft_strncmp(rl, "exit", 4) == 0)
-		return (1);
-	printf(PURPLE "42\n" RESET);
-	return (0);
+        if (ft_strncmp(rl, "exit", 4) == 0)
+                return (1);
+        if (ft_strncmp(rl, "echo ", 5) == 0)
+        {
+                builtin_echo(rl + 5);
+                return (0);
+        }
+        if (ft_strncmp(rl, "echo", 4) == 0 && rl[4] == '\0')
+        {
+                builtin_echo(NULL);
+                return (0);
+        }
+        printf(PURPLE "42\n" RESET);
+        return (0);
 }
 
 void	start_shell_loop(char **env)

--- a/minishell.h
+++ b/minishell.h
@@ -48,5 +48,6 @@ typedef struct s_data
 
 void	exit_msg(char *msg, int code);
 char	*prompt(void);
+void	builtin_echo(char *arg);
 
 #endif


### PR DESCRIPTION
## Summary
- add a minimal `echo` builtin that strips surrounding quotes
- compile new builtin via Makefile
- use builtin in `handle_input`

## Testing
- `make`
- `./minishell <<'EOF'
echo "aspas ->'"
exit
EOF`

