### PR TITLE
Update cd builtin to manage PWD/OLDPWD

### DIFF
--- a/cd.c
+++ b/cd.c
@@ -12,35 +12,69 @@
 
 #include "minishell.h"
 
-int	ft_cd(char **args, char **env)
+static void     update_env_var(t_shell *sh, const char *key, const char *val)
 {
-	char	*target;
-	char	cwd[4096];
+    int     i;
+    char    *tmp;
+    char    *entry;
 
-        if (args[1] && args[2])
+    tmp = ft_strjoin(key, "=");
+    if (!tmp)
+        return ;
+    entry = ft_strjoin(tmp, val);
+    free(tmp);
+    if (!entry)
+        return ;
+    i = 0;
+    while (sh->env && sh->env[i])
+    {
+        if (!ft_strncmp(sh->env[i], key, ft_strlen(key))
+            && sh->env[i][ft_strlen(key)] == '=')
         {
-                ft_putendl_fd("cd: too many arguments", 2);
-                return (1);
+            free(sh->env[i]);
+            sh->env[i] = ft_strdup(entry);
+            free(entry);
+            return ;
         }
-	if (!args[1])
-	{
-		target = getenv("HOME");
-		if (!target)
-		{
-			ft_putendl_fd("cd: HOME not set", 2);
-			return (1);
-		}
-	}
-	else
-		target = args[1];
-	if (chdir(target) != 0)
-	{
-		perror("cd");
-		return (1);
-	}
-	if (getcwd(cwd, sizeof(cwd)))
-	{
-		(void)env;
-	}
-	return (0);
+        i++;
+    }
+    sh->env = ft_strs_add(sh->env, entry);
+    free(entry);
+}
+
+int     ft_cd(char **args, t_shell *sh)
+{
+    char    *target;
+    char    cwd[4096];
+    char    old[4096];
+
+    if (args[1] && args[2])
+    {
+        ft_putendl_fd("cd: too many arguments", 2);
+        return (1);
+    }
+    if (getcwd(old, sizeof(old)) == NULL)
+        old[0] = '\0';
+    if (!args[1])
+    {
+        target = getenv("HOME");
+        if (!target)
+        {
+            ft_putendl_fd("cd: HOME not set", 2);
+            return (1);
+        }
+    }
+    else
+        target = args[1];
+    if (chdir(target) != 0)
+    {
+        perror("cd");
+        return (1);
+    }
+    if (getcwd(cwd, sizeof(cwd)))
+    {
+        update_env_var(sh, "OLDPWD", old);
+        update_env_var(sh, "PWD", cwd);
+    }
+    return (0);
 }

--- a/dispatcher.c
+++ b/dispatcher.c
@@ -31,8 +31,8 @@ int             run_builtin(t_cmd *cmd, t_shell *sh)
 		return (1);
 	if (!ft_strncmp(cmd->args[0], "echo", 5))
 		return (ft_echo(cmd->args));
-	if (!ft_strncmp(cmd->args[0], "cd", 3))
-		return (ft_cd(cmd->args, sh->env));
+        if (!ft_strncmp(cmd->args[0], "cd", 3))
+                return (ft_cd(cmd->args, sh));
 	if (!ft_strncmp(cmd->args[0], "pwd", 4))
 		return (ft_pwd());
 	if (!ft_strncmp(cmd->args[0], "exit", 5))

--- a/minishell.h
+++ b/minishell.h
@@ -166,7 +166,7 @@ void	sigint_handler(int sig);
 int		is_builtin(char *cmd);
 int             run_builtin(t_cmd *cmd, t_shell *sh);
 int		ft_pwd(void);
-int		ft_cd(char **args, char **env);
+int		ft_cd(char **args, t_shell *sh);
 int		ft_echo(char **args);
 int             ft_exit(char **args, t_shell *sh);
 int		ft_env(char **env);

--- a/tests/test_cd_pwd.py
+++ b/tests/test_cd_pwd.py
@@ -1,0 +1,29 @@
+import os
+import subprocess
+import tempfile
+import unittest
+
+class CdPwdTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        subprocess.run(["make"], check=True)
+
+    def run_shell(self, commands: str) -> str:
+        proc = subprocess.run(["./minishell"], input=commands.encode(), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        return proc.stdout.decode()
+
+    def test_cd_updates_pwd_vars(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            cmds = f"pwd\ncd {tmp}\npwd\necho $PWD\necho $OLDPWD\nexit\n"
+            raw = self.run_shell(cmds).splitlines()
+            out = [l for l in raw if not l.startswith('\x1b')]
+            self.assertGreaterEqual(len(out), 4)
+            first_pwd = out[0]
+            new_pwd = out[1]
+            env_pwd = out[2]
+            env_oldpwd = out[3]
+            self.assertEqual(new_pwd, env_pwd)
+            self.assertEqual(first_pwd, env_oldpwd)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- update `ft_cd` to set PWD and OLDPWD in shell env
- adjust dispatcher and header for new `ft_cd` signature
- add helper `update_env_var` to modify environment
- add regression tests for `cd` updating `PWD` and `OLDPWD`

## Testing
- `python -m unittest discover -s tests -v`
