### PR TITLE
Implement basic parser and command execution

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,8 @@ SRCS =	minishell.c\
 		utils.c\
 		prompt.c\
 		echo.c\
+		parse.c\
+		exec.c\
 
 # Object Files (automatiquement générés à partir de SRCS)
 OBJS = $(SRCS:.c=.o)

--- a/exec.c
+++ b/exec.c
@@ -1,0 +1,153 @@
+#include "minishell.h"
+
+static void free_split(char **tab)
+{
+    int i = 0;
+    if (!tab)
+        return ;
+    while (tab[i])
+        free(tab[i++]);
+    free(tab);
+}
+
+static char *find_command_path(char *cmd, char **env)
+{
+    char    *path_env;
+    char    **paths;
+    char    *joined;
+    int     i;
+
+    if (!cmd || ft_strchr(cmd, '/'))
+        return (ft_strdup(cmd));
+    path_env = getenv("PATH");
+    if (!path_env)
+    {
+        i = 0;
+        while (env && env[i])
+        {
+            if (ft_strncmp(env[i], "PATH=", 5) == 0)
+            {
+                path_env = env[i] + 5;
+                break ;
+            }
+            i++;
+        }
+    }
+    if (!path_env)
+        return (NULL);
+    paths = ft_split(path_env, ':');
+    i = 0;
+    while (paths && paths[i])
+    {
+        char *tmp = ft_strjoin(paths[i], "/");
+        joined = ft_strjoin(tmp, cmd);
+        free(tmp);
+        if (access(joined, X_OK) == 0)
+            return (free_split(paths), joined);
+        free(joined);
+        i++;
+    }
+    free_split(paths);
+    return (NULL);
+}
+
+static int open_redirs(t_cmd *cmd)
+{
+    int fd;
+
+    if (cmd->infile)
+    {
+        fd = open(cmd->infile, O_RDONLY);
+        if (fd < 0 || dup2(fd, STDIN_FILENO) < 0)
+            return (perror(cmd->infile), -1);
+        close(fd);
+    }
+    if (cmd->outfile)
+    {
+        fd = open(cmd->outfile, O_CREAT | O_WRONLY | O_TRUNC, 0644);
+        if (fd < 0 || dup2(fd, STDOUT_FILENO) < 0)
+            return (perror(cmd->outfile), -1);
+        close(fd);
+    }
+    return (0);
+}
+
+static void run_builtin(t_cmd *cmd)
+{
+    if (strcmp(cmd->args[0], "echo") == 0)
+        builtin_echo(cmd->args[1]);
+}
+
+int execute_commands(t_cmd *cmds, int count, char **env)
+{
+    int     i;
+    int     prev_fd = -1;
+    int     pipefd[2];
+    pid_t   *pids = malloc(sizeof(pid_t) * count);
+
+    if (!pids)
+        return (perror("malloc"), -1);
+    i = 0;
+    while (i < count)
+    {
+        if (i < count - 1 && pipe(pipefd) < 0)
+            return (perror("pipe"), free(pids), -1);
+        if (is_builtin(cmds[i].args[0]) && count == 1)
+        {
+            int save_in = dup(STDIN_FILENO);
+            int save_out = dup(STDOUT_FILENO);
+            if (open_redirs(&cmds[i]) < 0)
+                return (free(pids), -1);
+            run_builtin(&cmds[i]);
+            dup2(save_in, STDIN_FILENO);
+            dup2(save_out, STDOUT_FILENO);
+            close(save_in);
+            close(save_out);
+            free(pids);
+            return (0);
+        }
+        pids[i] = fork();
+        if (pids[i] == 0)
+        {
+            if (prev_fd != -1)
+            {
+                dup2(prev_fd, STDIN_FILENO);
+                close(prev_fd);
+            }
+            if (i < count - 1)
+            {
+                close(pipefd[0]);
+                dup2(pipefd[1], STDOUT_FILENO);
+                close(pipefd[1]);
+            }
+            if (open_redirs(&cmds[i]) < 0)
+                exit(1);
+            if (is_builtin(cmds[i].args[0]))
+            {
+                run_builtin(&cmds[i]);
+                exit(0);
+            }
+            char *path = find_command_path(cmds[i].args[0], env);
+            if (!path)
+                exit(1);
+            execve(path, cmds[i].args, env);
+            perror(cmds[i].args[0]);
+            exit(1);
+        }
+        if (prev_fd != -1)
+            close(prev_fd);
+        if (i < count - 1)
+        {
+            close(pipefd[1]);
+            prev_fd = pipefd[0];
+        }
+        i++;
+    }
+    if (prev_fd != -1)
+        close(prev_fd);
+    i = 0;
+    while (i < count)
+        waitpid(pids[i++], NULL, 0);
+    free(pids);
+    return (0);
+}

--- a/minishell.c
+++ b/minishell.c
@@ -12,21 +12,18 @@
 
 #include "minishell.h"
 
-int     handle_input(char *rl)
+int     handle_input(char *rl, char **env)
 {
-        if (ft_strncmp(rl, "exit", 4) == 0)
+        t_cmd   *cmds;
+        int             count;
+
+        if (ft_strncmp(rl, "exit", 4) == 0 && (rl[4] == '\0' || isspace((unsigned char)rl[4])))
                 return (1);
-        if (ft_strncmp(rl, "echo ", 5) == 0)
-        {
-                builtin_echo(rl + 5);
+        count = parse_input(rl, &cmds);
+        if (count <= 0)
                 return (0);
-        }
-        if (ft_strncmp(rl, "echo", 4) == 0 && rl[4] == '\0')
-        {
-                builtin_echo(NULL);
-                return (0);
-        }
-        printf(PURPLE "42\n" RESET);
+        execute_commands(cmds, count, env);
+        free_cmds(cmds, count);
         return (0);
 }
 
@@ -35,23 +32,22 @@ void	start_shell_loop(char **env)
 	char	*rl;
 	char	*prompt_str;
 
-	(void)env;
-	while (1)
-	{
-		prompt_str = prompt();
-		if (!prompt_str)
-			continue ;
-		rl = readline(prompt_str);
-		free(prompt_str);
-		if (!rl)
-			break ;
-		if (handle_input(rl))
-		{
-			free(rl);
-			break ;
-		}
-		free(rl);
-	}
+        while (1)
+        {
+                prompt_str = prompt();
+                if (!prompt_str)
+                        continue ;
+                rl = readline(prompt_str);
+                free(prompt_str);
+                if (!rl)
+                        break ;
+                if (handle_input(rl, env))
+                {
+                        free(rl);
+                        break ;
+                }
+                free(rl);
+        }
 }
 
 int	main(int argc, char **argv, char **env)

--- a/minishell.h
+++ b/minishell.h
@@ -18,6 +18,7 @@
 # include <stdbool.h>
 # include <stdio.h>
 # include <stdlib.h>
+# include <ctype.h>
 # include <readline/readline.h>
 # include <readline/history.h>
 # include <signal.h>
@@ -28,10 +29,10 @@
 # include <sys/wait.h>
 # include "./Libft/libft.h"
 
-# define ERROR	1
+# define ERROR  1
 
-# define BLACK	"\e[30m"
-# define RED	"\e[31m"
+# define BLACK  "\e[30m"
+# define RED    "\e[31m"
 # define GREEN  "\e[32m"
 # define YELLOW "\e[33m"
 # define BLUE   "\e[34m"
@@ -40,14 +41,26 @@
 # define WHITE  "\e[37m"
 # define RESET  "\e[0m"
 
-# define ARGS	"This program does not allow any arguments!"
+# define ARGS   "This program does not allow any arguments!"
 
 typedef struct s_data
 {
-}	t_data;
+}       t_data;
 
-void	exit_msg(char *msg, int code);
-char	*prompt(void);
-void	builtin_echo(char *arg);
+typedef struct s_cmd
+{
+    char    **args;
+    char    *infile;
+    char    *outfile;
+}       t_cmd;
+
+int     parse_input(char *line, t_cmd **cmds);
+void    free_cmds(t_cmd *cmds, int count);
+int     execute_commands(t_cmd *cmds, int count, char **env);
+bool    is_builtin(char *cmd);
+
+void    exit_msg(char *msg, int code);
+char    *prompt(void);
+void    builtin_echo(char *arg);
 
 #endif

--- a/parse.c
+++ b/parse.c
@@ -1,0 +1,127 @@
+#include "minishell.h"
+
+static int count_parts(char **parts)
+{
+    int i = 0;
+    if (!parts)
+        return (0);
+    while (parts[i])
+        i++;
+    return (i);
+}
+
+static char *ft_strdup_safe(char *s)
+{
+    if (!s)
+        return (NULL);
+    return (ft_strdup(s));
+}
+
+static void free_split(char **tab)
+{
+    int i = 0;
+    if (!tab)
+        return ;
+    while (tab[i])
+        free(tab[i++]);
+    free(tab);
+}
+
+static void fill_cmd(t_cmd *cmd, char **tokens)
+{
+    int i = 0;
+    int argc = 0;
+
+    cmd->infile = NULL;
+    cmd->outfile = NULL;
+    while (tokens[i])
+    {
+        if (strcmp(tokens[i], "<") == 0 && tokens[i + 1])
+        {
+            cmd->infile = ft_strdup_safe(tokens[i + 1]);
+            i += 2;
+        }
+        else if (strcmp(tokens[i], ">") == 0 && tokens[i + 1])
+        {
+            cmd->outfile = ft_strdup_safe(tokens[i + 1]);
+            i += 2;
+        }
+        else
+        {
+            argc++;
+            i++;
+        }
+    }
+    cmd->args = malloc(sizeof(char *) * (argc + 1));
+    i = 0;
+    argc = 0;
+    while (tokens[i])
+    {
+        if (strcmp(tokens[i], "<") == 0 || strcmp(tokens[i], ">") == 0)
+        {
+            i += 2;
+            continue ;
+        }
+        cmd->args[argc++] = ft_strdup_safe(tokens[i]);
+        i++;
+    }
+    cmd->args[argc] = NULL;
+}
+
+int parse_input(char *line, t_cmd **cmds_out)
+{
+    char    **parts;
+    int     count;
+    int     i;
+
+    parts = ft_split(line, '|');
+    count = count_parts(parts);
+    if (count == 0)
+    {
+        *cmds_out = NULL;
+        free_split(parts);
+        return (0);
+    }
+    *cmds_out = malloc(sizeof(t_cmd) * count);
+    if (!*cmds_out)
+        return (free_split(parts), 0);
+    i = 0;
+    while (i < count)
+    {
+        char **tokens = ft_split(parts[i], ' ');
+        if (!tokens)
+            return (free_split(parts), free(*cmds_out), *cmds_out = NULL, 0);
+        fill_cmd(&(*cmds_out)[i], tokens);
+        free_split(tokens);
+        i++;
+    }
+    free_split(parts);
+    return (count);
+}
+
+void free_cmds(t_cmd *cmds, int count)
+{
+    int i, j;
+
+    if (!cmds)
+        return ;
+    i = 0;
+    while (i < count)
+    {
+        j = 0;
+        while (cmds[i].args && cmds[i].args[j])
+            free(cmds[i].args[j++]);
+        free(cmds[i].args);
+        free(cmds[i].infile);
+        free(cmds[i].outfile);
+        i++;
+    }
+    free(cmds);
+}
+
+bool is_builtin(char *cmd)
+{
+    if (!cmd)
+        return (false);
+    return (strcmp(cmd, "echo") == 0);
+}


### PR DESCRIPTION
## Summary
- add command parsing and execution helpers
- handle pipes and redirections with fork/exec
- update main loop to use new parser
- extend Makefile with new sources

## Testing
- `make`
- `printf 'echo hi | cat\nexit\n' | ./minishell`


------
https://chatgpt.com/codex/tasks/task_e_685abf5648dc832aa0f52a62d074c8ee