### PR TITLE
Remove global lexer error variable

### DIFF
--- a/lexer.c
+++ b/lexer.c
@@ -12,46 +12,46 @@
 
 #include "minishell.h"
 
-int	g_lexer_error = 0;
-
-t_token	*lexer_loop(char *s, int *i)
+t_token *lexer_loop(char *s, int *i, int *error)
 {
-	t_token	*head;
-	t_token	*cur;
-	t_token	*new;
-	char	*val;
+    t_token *head;
+    t_token *cur;
+    t_token *new;
+    char    *val;
 
-	head = NULL;
-	val = extract_token(s, i);
-	while (val != NULL)
-	{
-		new = malloc(sizeof(t_token));
-		if (new == NULL)
-			return (free_tokens(head), NULL);
-		new->content = val;
-		new->type = get_type(val);
-		new->next = NULL;
-		if (head == NULL)
-			head = new;
-		else
-			cur->next = new;
-		cur = new;
-		val = extract_token(s, i);
-	}
-	return (head);
+    head = NULL;
+    val = extract_token(s, i, error);
+    while (val != NULL)
+    {
+        new = malloc(sizeof(t_token));
+        if (new == NULL)
+            return (free_tokens(head), NULL);
+        new->content = val;
+        new->type = get_type(val);
+        new->next = NULL;
+        if (head == NULL)
+            head = new;
+        else
+            cur->next = new;
+        cur = new;
+        val = extract_token(s, i, error);
+    }
+    return (head);
 }
 
-t_token	*lexer(char *s)
+t_token *lexer(char *s, int *error)
 {
-	t_token	*head;
-	int		i;
+    t_token *head;
+    int     i;
 
-	i = 0;
-	head = lexer_loop(s, &i);
-	if (g_lexer_error != 0)
-	{
-		free_tokens(head);
-		return (NULL);
-	}
-	return (head);
+    i = 0;
+    if (error)
+        *error = 0;
+    head = lexer_loop(s, &i, error);
+    if (error && *error != 0)
+    {
+        free_tokens(head);
+        return (NULL);
+    }
+    return (head);
 }

--- a/lexer_token.c
+++ b/lexer_token.c
@@ -27,7 +27,7 @@ int	scan_token(char *s, int *i, int *in_s, int *in_d)
 	return (*in_s || *in_d);
 }
 
-char	*extract_token(char *s, int *i)
+char    *extract_token(char *s, int *i, int *error)
 {
 	int	start;
 	int	in_s;
@@ -49,7 +49,7 @@ char	*extract_token(char *s, int *i)
 		in_s = 0;
 		in_d = 0;
 		if (scan_token(s, i, &in_s, &in_d))
-			return (quote_error(in_s), NULL);
+			return (quote_error(in_s, error), NULL);
 	}
 	return (ft_substr(s, start, *i - start));
 }

--- a/lexer_utils.c
+++ b/lexer_utils.c
@@ -28,7 +28,7 @@ int	is_special(char c)
 	return (0);
 }
 
-void	quote_error(int in_s)
+void    quote_error(int in_s, int *error)
 {
 	ft_putstr_fd("minishell: unexpected EOF while looking for matching '", 2);
 	if (in_s)
@@ -36,5 +36,6 @@ void	quote_error(int in_s)
 	else
 		ft_putchar_fd('"', 2);
 	ft_putendl_fd("'", 2);
-	g_lexer_error = 1;
+        if (error)
+                *error = 1;
 }

--- a/minishell.h
+++ b/minishell.h
@@ -57,7 +57,6 @@ typedef struct s_shell
 }	t_shell;
 
 extern volatile sig_atomic_t	g_signal;
-extern int						g_lexer_error;
 
 typedef enum e_type
 {
@@ -101,11 +100,11 @@ void	start_shell_loop(t_shell *sh);
 /*                                    Lexer                                   */
 /* ************************************************************************** */
 
-t_token	*lexer(char *s);
-char	*extract_token(char *s, int *i);
+t_token *lexer(char *s, int *error);
+char *extract_token(char *s, int *i, int *error);
 int		is_space(char c);
 int		is_special(char c);
-void	quote_error(int in_s);
+void    quote_error(int in_s, int *error);
 t_type	get_type(char *s);
 void	free_tokens(t_token *tok);
 

--- a/prompt.c
+++ b/prompt.c
@@ -46,11 +46,13 @@ static int	handle_input(char *rl, t_shell *sh)
 	if (!rl || rl[0] == '\0')
 		return (0);
 	add_history(rl);
-	tokens = lexer(rl);
-	if (!tokens)
-	{
-		if (g_lexer_error)
-			sh->last_exit_status = 2;
+        tokens = NULL;
+        int err = 0;
+        tokens = lexer(rl, &err);
+        if (!tokens)
+        {
+                if (err)
+                        sh->last_exit_status = 2;
 		return (0);
 	}
 	cmds = parse(tokens, sh);


### PR DESCRIPTION
## Summary
- keep only one global variable by removing `g_lexer_error`
- return lexer errors through parameters instead
- adjust prompt to check returned error flag

## Testing
- `make`
- `printf 'echo hi\nexit\n' | ./minishell`

------
https://chatgpt.com/codex/tasks/task_e_685b250afcbc832a9fe6476aac629a6f